### PR TITLE
Add macvlan and DHCP support to Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,17 @@ ENV QLC_DEPENDS="\
     libusb-1.0-0 \
     libxcb-cursor0 \
     libxcb-xinerama0 \
-    bash" 
+    bash"
+
+#networking packages for macvlan and DHCP support
+ENV NETWORK_DEPENDS="\
+    dhcp-client \
+    iproute2 \
+    iputils-ping \
+    net-tools" 
 
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y ${QLC_DEPENDS} 
+RUN apt-get install -y ${QLC_DEPENDS} ${NETWORK_DEPENDS}
 RUN apt-get clean
 
 #download and install QLC+ Version 4.13.1


### PR DESCRIPTION
- Add networking packages (dhcp-client, iproute2, iputils-ping, net-tools)
- Enable container to work with macvlan networks and obtain DHCP addresses
- Supports getting IP directly from DHCP server when using macvlan driver

🤖 Generated with [Claude Code](https://claude.ai/code)