### PR TITLE
Add DHCP network configuration to entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get install -y ${QLC_DEPENDS}
 RUN apt-get clean
 
 #download and install QLC+ Version 4.13.1
-ARG QLC_VERSION=4.13.1
+ARG QLC_VERSION=4.14.3
 ADD https://www.qlcplus.org/downloads/${QLC_VERSION}/qlcplus_${QLC_VERSION}_amd64.deb qlcplus.deb
 
 RUN dpkg -i qlcplus.deb

--- a/qlcplus.sh
+++ b/qlcplus.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 echo "Running entrypoint script"
+
+# Configure network interface for macvlan with DHCP
+echo "Configuring network interface..."
+dhclient eth0
+ip addr show eth0
+
 source /QLC/qt_export.sh
 qlcplus -w -o /QLC/qlc.qxw -p


### PR DESCRIPTION
- Add dhclient eth0 and ip addr show eth0 commands to entrypoint
- Ensures proper network configuration before QLC+ starts
- Updated QLC+ version to 4.14.3
- Supports macvlan networking with automatic DHCP configuration

🤖 Generated with [Claude Code](https://claude.ai/code)